### PR TITLE
Persist CTC window position

### DIFF
--- a/SignalsEverywhere/Panel/CTCPanel.cs
+++ b/SignalsEverywhere/Panel/CTCPanel.cs
@@ -87,8 +87,7 @@ public class CTCPanel : WindowBase
 
     public void Show()
     {
-        var rect = GetComponent<RectTransform>();
-        rect.position = new Vector2(Screen.width, Screen.height - 40);
+        WindowPersistence.SetInitialPositionSize(Shared.Window, WindowIdentifier, DefaultSize, DefaultPosition, Sizing);
         Window.ShowWindow();
         Rebuild();
     }


### PR DESCRIPTION
## Context

- The default CTC panel location blocks AE notices in the top right so I usually move the panel to see, but closing it and reopening it moves it back to the original position.

## Description

- Uses vanilla `WindowPersistence` to persist the player's preferred window positioning.

## Testing

- Tested locally and the CTC panel will successfully reappear wherever the player had it last.